### PR TITLE
unify-kube-capabilities

### DIFF
--- a/kubernetes/aks/blueprint.yaml
+++ b/kubernetes/aks/blueprint.yaml
@@ -298,6 +298,6 @@ capabilities:
 
 outputs:
 
-  endpoint:
+  kubernetes_cluster_host:
     description: Kubernetes endpoint
     value: { get_attribute: [managed_cluster, kubeconf, clusters, 0, cluster, server ] }

--- a/kubernetes/eks-istio/blueprint.yaml
+++ b/kubernetes/eks-istio/blueprint.yaml
@@ -863,7 +863,7 @@ labels:
 
 capabilities:
 
-  endpoint:
+  kubernetes_cluster_host:
     value: { get_attribute: [eks_cluster, kubeconf, clusters, 0, cluster, server ] }
 
   token:
@@ -882,5 +882,5 @@ capabilities:
 
 outputs:
 
-  endpoint:
+  kubernetes_cluster_host:
     value: { get_attribute: [eks_cluster, kubeconf, clusters, 0, cluster, server ] }

--- a/kubernetes/eks/blueprint.yaml
+++ b/kubernetes/eks/blueprint.yaml
@@ -774,7 +774,7 @@ capabilities:
     value: *kubernetes_master_configuration
 
 outputs:
-  endpoint:
+  kubernetes_cluster_host:
     description: Kubernetes endpoint
     value:
       { get_attribute: [eks_cluster, kubeconf, clusters, 0, cluster, server] }

--- a/kubernetes/gke/blueprint.yaml
+++ b/kubernetes/gke/blueprint.yaml
@@ -21,6 +21,18 @@ inputs:
     type: string
     default: ex2
 
+  service_account_name:
+    description: Service Account name
+    display_label: Service Account Name
+    type: string
+    default: examples-user
+
+  service_account_namespace:
+    description: Service Account Namespace
+    display_label: Service Account Namespace
+    type: string
+    default: default
+
 dsl_definitions:
 
   gcp_config: &gcp_config
@@ -61,6 +73,105 @@ node_templates:
     relationships:
       - type: cloudify.relationships.depends_on
         target: kubernetes-cluster
+
+  new_service_account:
+    type: cloudify.kubernetes.resources.ServiceAccount
+    properties:
+      client_config: &kube_client_config
+        authentication: 
+          gcp_service_account: { get_secret: gcp_credentials }
+        configuration:
+          api_options:
+            host: { concat: [ 'https://', { get_attribute: [kubernetes-cluster-attributes, endpoint] }]}
+            verify_ssl: false
+            debug: false
+      definition:
+        apiVersion: v1
+        kind: ServiceAccount
+        metadata:
+          name: { get_input: service_account_name }
+          namespace: { get_input: service_account_namespace }
+      options:
+        namespace: { get_input: service_account_namespace }
+    relationships:
+      - type: cloudify.relationships.depends_on
+        target: kubernetes-cluster
+
+  new_role_binding:
+    type: cloudify.kubernetes.resources.RoleBinding
+    properties:
+      client_config: *kube_client_config
+      definition:
+        apiVersion: rbac.authorization.k8s.io/v1
+        kind: ClusterRoleBinding
+        metadata:
+          name: { get_input: service_account_name }
+        roleRef:
+          apiGroup: rbac.authorization.k8s.io
+          kind: ClusterRole
+          name: cluster-admin
+        subjects:
+        - kind: ServiceAccount
+          name: { get_input: service_account_name }
+          namespace: { get_input: service_account_namespace }
+      options:
+        namespace: { get_input: service_account_namespace }
+    relationships:
+      - type: cloudify.relationships.depends_on
+        target: kubernetes-cluster
+      - type: cloudify.relationships.depends_on
+        target: new_service_account
+
+  secret:
+    type: cloudify.kubernetes.resources.CustomBlueprintDefinedResource
+    properties:
+      client_config: *kube_client_config
+      use_external_resource: true
+      definition:
+        apiVersion: v1
+        kind: Secret
+        metadata:
+          name: {get_attribute: [new_service_account, kubernetes, secrets, 0, name]}
+      api_mapping:
+        create:
+          api: CoreV1Api
+          method: create_namespaced_secret
+          payload: V1Secret
+        read:
+          api: CoreV1Api
+          method: read_namespaced_secret
+        update:
+          api: CoreV1Api
+          method: replace_namespaced_secret
+          payload: V1Secret
+        delete:
+          api: CoreV1Api
+          method: delete_namespaced_secret
+          payload: V1DeleteOptions
+    relationships:
+      - type: cloudify.relationships.depends_on
+        target: kubernetes-cluster
+      - type: cloudify.relationships.depends_on
+        target: new_role_binding
+      - type: cloudify.relationships.depends_on
+        target: new_service_account
+    interfaces:
+      cloudify.interfaces.lifecycle:
+        delete: {}
+
+  store_token_and_kubeconfig:
+    type: cloudify.nodes.Root
+    interfaces:
+      cloudify.interfaces.lifecycle:
+        create:
+          implementation: scripts/store_kube_token_and_config.py
+          executor: central_deployment_agent
+          inputs:
+            kube_token: { get_attribute: [ secret, kubernetes, data, token ] }
+            ssl_certificate: { get_attribute: [kubernetes-cluster-attributes, masterAuth, clusterCaCertificate] }
+    relationships:
+      - type: cloudify.relationships.depends_on
+        target: secret
 
   sanity_pod:
     type: cloudify.kubernetes.resources.FileDefinedResource
@@ -104,12 +215,17 @@ labels:
 
 capabilities:
 
-  endpoint:
-    description: Endpoint
+  kubernetes_cluster_host:
     value: { concat: [ 'https://', { get_attribute: [kubernetes-cluster-attributes, endpoint] }]}
+
+  token:
+    value: { get_attribute: [ store_token_and_kubeconfig, token ] }
+
+  ssl_ca_cert:
+    value: { get_attribute: [ store_token_and_kubeconfig, ssl_ca_cert ] }
 
 outputs:
 
-  endpoint:
+  kubernetes_cluster_host:
     description: Endpoint
     value: { concat: [ 'https://', { get_attribute: [kubernetes-cluster-attributes, endpoint] }]}

--- a/kubernetes/gke/scripts/store_kube_token_and_config.py
+++ b/kubernetes/gke/scripts/store_kube_token_and_config.py
@@ -1,0 +1,10 @@
+import base64
+import json
+
+from cloudify import ctx
+from cloudify.state import ctx_parameters as inputs
+
+token = base64.b64decode(inputs['kube_token']).decode('utf-8')
+ctx.instance.runtime_properties['token'] = token
+ssl_ca_cert = base64.b64decode(inputs['ssl_certificate']).decode('utf-8')
+ctx.instance.runtime_properties['ssl_ca_cert'] = ssl_ca_cert

--- a/terraform/eks-istio/README.md
+++ b/terraform/eks-istio/README.md
@@ -19,6 +19,7 @@ The blueprint uses secrets to connect to cloud, you need to configure them prior
 | --------------------- | ---------------------------------------------------------------------------------- |
 | aws_access_key_id     | AWS Access Key ID                                                                  |
 | aws_aceess_secret_key | AWS Access Secret Key                                                              |
+| kubernetes_token      | a dummy value - changeme                                                           |
 
 ## Plugins
 

--- a/terraform/eks-istio/blueprint.yaml
+++ b/terraform/eks-istio/blueprint.yaml
@@ -170,6 +170,19 @@ node_templates:
       - target: vpc
         type: cloudify.relationships.depends_on
 
+  store_token:
+    type: cloudify.nodes.Root
+    interfaces:
+      cloudify.interfaces.lifecycle:
+        create:
+          implementation: scripts/store_kube_token.py
+          executor: central_deployment_agent
+          inputs:
+            kube_token: { get_attribute: [ eks_cluster, outputs, cluster_token, value ] }
+    relationships:
+      - type: cloudify.relationships.depends_on
+        target: eks_cluster
+
   service_account:
     type: cloudify.nodes.terraform.Module
     properties:
@@ -180,12 +193,25 @@ node_templates:
         variables:
           cluster_endpoint: { get_attribute: [ eks_cluster, outputs, cluster_endpoint, value ] }
           cluster_certificate_authority: { get_attribute: [ eks_cluster, outputs, cluster_certificate_authority, value ] }
-          cluster_token: { get_attribute: [ eks_cluster, outputs, cluster_token, value ] }
+          cluster_token: { get_secret: kubernetes_token }
     relationships:
       - target: terraform
         type: cloudify.terraform.relationships.run_on_host
       - target: eks_cluster
         type: cloudify.relationships.depends_on
+
+  update_token:
+    type: cloudify.nodes.Root
+    interfaces:
+      cloudify.interfaces.lifecycle:
+        create:
+          implementation: scripts/store_kube_token.py
+          executor: central_deployment_agent
+          inputs:
+            kube_token: { get_attribute: [ service_account, outputs, cluster_service_account_token, value ] }
+    relationships:
+      - type: cloudify.relationships.depends_on
+        target: service_account
 
   istio:
     type: cloudify.nodes.terraform.Module
@@ -197,7 +223,7 @@ node_templates:
         variables:
           cluster_endpoint: { get_attribute: [ eks_cluster, outputs, cluster_endpoint, value ] }
           cluster_certificate_authority: { get_attribute: [ eks_cluster, outputs, cluster_certificate_authority, value ] }
-          cluster_token: { get_attribute: [ service_account, outputs, cluster_service_account_token, value ] }
+          cluster_token: { get_secret: kubernetes_token }
     relationships:
       - target: terraform
         type: cloudify.terraform.relationships.run_on_host
@@ -209,13 +235,13 @@ capabilities:
   aws_region:
     value: { get_input: region }
 
-  cluster_endpoint:
+  kubernetes_cluster_host:
     value: { get_attribute: [ eks_cluster, outputs, cluster_endpoint, value ] }
 
-  cluster_certificate_authority:
+  ssl_ca_cert:
     value: { get_attribute: [ eks_cluster, outputs, cluster_certificate_authority, value ] }
 
-  cluster_token:
+  token:
     value: { get_attribute: [ service_account, outputs, cluster_service_account_token, value ] }
 
   istio_ingress:

--- a/terraform/eks-istio/scripts/store_kube_token.py
+++ b/terraform/eks-istio/scripts/store_kube_token.py
@@ -1,0 +1,7 @@
+from cloudify import ctx
+from cloudify.state import ctx_parameters as inputs
+from cloudify.manager import get_rest_client
+
+client = get_rest_client()
+token = inputs['kube_token']
+client.secrets.create('kubernetes_token', token, update_if_exists=True)


### PR DESCRIPTION
Make some examples with unified capabilities as other blueprints [ when other deployments -services- is referencing them as parent, they would work fine ] 

what we want to have are these capabilities as the standard ones 
```
	kubernetes_cluster_host, 
	token, 
	ssl_ca_cert
```